### PR TITLE
Enable Fastly cache purger to read secrets from SSM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,11 +21,6 @@ assemblyJarName := s"${name.value}.jar"
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.0",
-  "com.squareup.okhttp3" % "okhttp" % "4.9.2",
-  "org.apache.logging.log4j" % "log4j-api" % log4jVersion,
-  "org.apache.logging.log4j" % "log4j-core" % log4jVersion,
-  "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4jVersion,
-  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.1",
-  "org.slf4j" % "slf4j-api" % "2.0.7"
+  "com.squareup.okhttp3" % "okhttp" % "4.9.2"
 
 )

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ description:= "Lambda function which purges the Fastly cache from mobile front."
 version := "1.0"
 
 scalaVersion := "2.13.10"
+val log4jVersion = "2.17.1"
 
 scalacOptions ++= Seq(
   "-deprecation",
@@ -18,5 +19,13 @@ scalacOptions ++= Seq(
 assemblyJarName := s"${name.value}.jar"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-lambda-java-core" % "1.2.2"
+  "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",
+  "com.amazonaws" % "aws-lambda-java-events" % "3.11.0",
+  "com.squareup.okhttp3" % "okhttp" % "4.9.2",
+  "org.apache.logging.log4j" % "log4j-api" % log4jVersion,
+  "org.apache.logging.log4j" % "log4j-core" % log4jVersion,
+  "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4jVersion,
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.1",
+  "org.slf4j" % "slf4j-api" % "2.0.7"
+
 )

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,11 @@ scalacOptions ++= Seq(
 
 assemblyJarName := s"${name.value}.jar"
 
+assembly / assemblyMergeStrategy := {
+  case "META-INF/MANIFEST.MF" => MergeStrategy.discard
+  case _ => MergeStrategy.first
+}
+
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.0",

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,6 @@ assemblyJarName := s"${name.value}.jar"
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.0",
-  "com.squareup.okhttp3" % "okhttp" % "4.9.2"
-
+  "com.squareup.okhttp3" % "okhttp" % "4.9.2",
+  "com.gu" %% "simple-configuration-ssm" % "1.5.6"
 )

--- a/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
@@ -15,6 +15,15 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
+    "FastlyAPIKey": {
+      "Description": "API key with purge writes for service with id FastlyServiceId",
+      "NoEcho": true,
+      "Type": "String",
+    },
+    "FastlyServiceId": {
+      "Description": "Id of service to purge",
+      "Type": "String",
+    },
   },
   "Resources": {
     "mobilefastlycachepurgerFDB90D2A": {
@@ -33,6 +42,12 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
           "Variables": {
             "APP": "mobile-fastly-cache-purger",
             "App": "mobile-fastly-cache-purger",
+            "FastlyAPIKey": {
+              "Ref": "FastlyAPIKey",
+            },
+            "FastlyServiceId": {
+              "Ref": "FastlyServiceId",
+            },
             "STACK": "mobile-fastly-cache-purger",
             "STAGE": "TEST",
             "Stack": "mobile-fastly-cache-purger",

--- a/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
@@ -51,7 +51,7 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
                         {
                           "Ref": "AWS::AccountId",
                         },
-                        ":parameter/mobile-fastly-cache-purger/TEST",
+                        ":parameter/cache-purger/TEST",
                       ],
                     ],
                   },

--- a/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
@@ -37,7 +37,10 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
             "PolicyDocument": {
               "Statement": [
                 {
-                  "Action": "ssm:GetParameterByPath",
+                  "Action": [
+                    "ssm:GetParametersByPath",
+                    "ssm:GetParameter",
+                  ],
                   "Effect": "Allow",
                   "Resource": "arn:aws:ssm:undefined:undefined:parameter/mobile-fastly-cache-purger/TEST",
                 },

--- a/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
@@ -37,7 +37,7 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
             "PolicyDocument": {
               "Statement": [
                 {
-                  "Action": "ssm:GetParametersByPath",
+                  "Action": "ssm:GetParameterByPath",
                   "Effect": "Allow",
                   "Resource": "arn:aws:ssm:undefined:undefined:parameter/mobile-fastly-cache-purger/TEST",
                 },

--- a/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
@@ -37,12 +37,24 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
             "PolicyDocument": {
               "Statement": [
                 {
-                  "Action": [
-                    "ssm:GetParametersByPath",
-                    "ssm:GetParameter",
-                  ],
+                  "Action": "ssm:GetParametersByPath",
                   "Effect": "Allow",
-                  "Resource": "arn:aws:ssm:undefined:undefined:parameter/mobile-fastly-cache-purger/TEST",
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:aws:ssm:",
+                        {
+                          "Ref": "AWS::Region",
+                        },
+                        ":",
+                        {
+                          "Ref": "AWS::AccountId",
+                        },
+                        ":parameter/mobile-fastly-cache-purger/TEST",
+                      ],
+                    ],
+                  },
                 },
               ],
               "Version": "2012-10-17",

--- a/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
@@ -15,82 +15,9 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "FastlyAPIKey": {
-      "Description": "API key with purge writes for service with id FastlyServiceId",
-      "NoEcho": true,
-      "Type": "String",
-    },
-    "FastlyServiceId": {
-      "Description": "Id of service to purge",
-      "Type": "String",
-    },
   },
   "Resources": {
-    "mobilefastlycachepurgerFDB90D2A": {
-      "DependsOn": [
-        "mobilefastlycachepurgerServiceRoleDefaultPolicy6A603663",
-        "mobilefastlycachepurgerServiceRole9FC22BE4",
-      ],
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "DistributionBucketName",
-          },
-          "S3Key": "mobile-fastly-cache-purger/TEST/mobile-fastly-cache-purger/mobile-fastly-cache-purger.jar",
-        },
-        "Environment": {
-          "Variables": {
-            "APP": "mobile-fastly-cache-purger",
-            "App": "mobile-fastly-cache-purger",
-            "FastlyAPIKey": {
-              "Ref": "FastlyAPIKey",
-            },
-            "FastlyServiceId": {
-              "Ref": "FastlyServiceId",
-            },
-            "STACK": "mobile-fastly-cache-purger",
-            "STAGE": "TEST",
-            "Stack": "mobile-fastly-cache-purger",
-            "Stage": "TEST",
-          },
-        },
-        "FunctionName": "mobile-fastly-cache-purger-cdk-TEST",
-        "Handler": "PurgerLambda::handleRequest",
-        "MemorySize": 1024,
-        "Role": {
-          "Fn::GetAtt": [
-            "mobilefastlycachepurgerServiceRole9FC22BE4",
-            "Arn",
-          ],
-        },
-        "Runtime": "java11",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "mobile-fastly-cache-purger",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/mobile-fastly-cache-purger",
-          },
-          {
-            "Key": "Stack",
-            "Value": "mobile-fastly-cache-purger",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "Timeout": 60,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "mobilefastlycachepurgerServiceRole9FC22BE4": {
+    "ExecutionRole605A040B": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -104,25 +31,23 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": [
+        "Path": "/",
+        "Policies": [
           {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
+            "PolicyDocument": {
+              "Statement": [
                 {
-                  "Ref": "AWS::Partition",
+                  "Action": "ssm:GetParametersByPath",
+                  "Effect": "Allow",
+                  "Resource": "arn:aws:ssm:undefined:undefined:parameter/mobile-fastly-cache-purger/TEST",
                 },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
               ],
-            ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "Conf",
           },
         ],
         "Tags": [
-          {
-            "Key": "App",
-            "Value": "mobile-fastly-cache-purger",
-          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -143,7 +68,7 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "mobilefastlycachepurgerServiceRoleDefaultPolicy6A603663": {
+    "ExecutionRoleDefaultPolicyA5B92313": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -234,14 +159,72 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "mobilefastlycachepurgerServiceRoleDefaultPolicy6A603663",
+        "PolicyName": "ExecutionRoleDefaultPolicyA5B92313",
         "Roles": [
           {
-            "Ref": "mobilefastlycachepurgerServiceRole9FC22BE4",
+            "Ref": "ExecutionRole605A040B",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "mobilefastlycachepurgerFDB90D2A": {
+      "DependsOn": [
+        "ExecutionRoleDefaultPolicyA5B92313",
+        "ExecutionRole605A040B",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "mobile-fastly-cache-purger/TEST/mobile-fastly-cache-purger/mobile-fastly-cache-purger.jar",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "mobile-fastly-cache-purger",
+            "App": "mobile-fastly-cache-purger",
+            "STACK": "mobile-fastly-cache-purger",
+            "STAGE": "TEST",
+            "Stack": "mobile-fastly-cache-purger",
+            "Stage": "TEST",
+          },
+        },
+        "FunctionName": "mobile-fastly-cache-purger-cdk-TEST",
+        "Handler": "PurgerLambda::handleRequest",
+        "MemorySize": 1024,
+        "Role": {
+          "Fn::GetAtt": [
+            "ExecutionRole605A040B",
+            "Arn",
+          ],
+        },
+        "Runtime": "java11",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "mobile-fastly-cache-purger",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-fastly-cache-purger",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-fastly-cache-purger",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 60,
+      },
+      "Type": "AWS::Lambda::Function",
     },
   },
 }

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -4,10 +4,25 @@ import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import type { App } from 'aws-cdk-lib';
 import {Duration} from 'aws-cdk-lib';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import * as iam from 'aws-cdk-lib/aws-iam'
 
 export class MobileFastlyCachePurger extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
 		super(scope, id, props);
+
+		const executionRole = new iam.Role(this, 'ExecutionRole', {
+			assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+			path: "/",
+			inlinePolicies: {
+				Conf: new iam.PolicyDocument({
+					statements: [
+						new iam.PolicyStatement({
+							actions: [ 'ssm:GetParametersByPath' ],
+							resources: [ `arn:aws:ssm:${scope.region}:${scope.account}:parameter/cache-purger/${this.stage}` ]
+						})
+					] }),
+			}
+		})
 
 		new GuLambdaFunction(this, 'mobile-fastly-cache-purger', {
 			handler: 'PurgerLambda::handleRequest',
@@ -21,6 +36,7 @@ export class MobileFastlyCachePurger extends GuStack {
 			runtime: Runtime.JAVA_11,
 			app: 'mobile-fastly-cache-purger',
 			fileName: `mobile-fastly-cache-purger.jar`,
+			role: executionRole,
 		});
 	}
 }

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -1,33 +1,19 @@
-import { join } from 'path';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import type { App } from 'aws-cdk-lib';
-import {CfnParameter, Duration} from 'aws-cdk-lib';
+import {Duration} from 'aws-cdk-lib';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
 export class MobileFastlyCachePurger extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
 		super(scope, id, props);
 
-		const fastlyServiceId = new CfnParameter(this, 'FastlyServiceId', {
-			type: 'String',
-			description: 'Id of service to purge',
-		});
-		const fastlyAPIKey = new CfnParameter(this, 'FastlyAPIKey', {
-			type: 'String',
-			description:
-				'API key with purge writes for service with id FastlyServiceId',
-			noEcho: true,
-		});
-
 		new GuLambdaFunction(this, 'mobile-fastly-cache-purger', {
 			handler: 'PurgerLambda::handleRequest',
 			functionName: `mobile-fastly-cache-purger-cdk-${this.stage}`,
 			timeout: Duration.seconds(60),
 			environment: {
-				FastlyServiceId: fastlyServiceId.valueAsString,
-				FastlyAPIKey: fastlyAPIKey.valueAsString,
 				App: 'mobile-fastly-cache-purger',
 				Stack: this.stack,
 				Stage: this.stage,

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -17,7 +17,7 @@ export class MobileFastlyCachePurger extends GuStack {
 				Conf: new iam.PolicyDocument({
 					statements: [
 						new iam.PolicyStatement({
-							actions: [ 'ssm:GetParametersByPath' ],
+							actions: [ 'ssm:GetParameterByPath' ],
 							resources: [ `arn:aws:ssm:${scope.region}:${scope.account}:parameter/mobile-fastly-cache-purger/${this.stage}` ]
 						})
 					] }),

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -18,7 +18,7 @@ export class MobileFastlyCachePurger extends GuStack {
 					statements: [
 						new iam.PolicyStatement({
 							actions: [ 'ssm:GetParametersByPath' ],
-							resources: [ `arn:aws:ssm:${scope.region}:${scope.account}:parameter/cache-purger/${this.stage}` ]
+							resources: [ `arn:aws:ssm:${scope.region}:${scope.account}:parameter/mobile-fastly-cache-purger/${this.stage}` ]
 						})
 					] }),
 			}

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -18,7 +18,7 @@ export class MobileFastlyCachePurger extends GuStack {
 					statements: [
 						new iam.PolicyStatement({
 							actions: [ 'ssm:GetParametersByPath' ],
-							resources: [ `arn:aws:ssm:${scope.region}:${scope.account}:parameter/mobile-fastly-cache-purger/${this.stage}` ]
+							resources: [ `arn:aws:ssm:${this.region}:${this.account}:parameter/mobile-fastly-cache-purger/${this.stage}` ]
 						})
 					] }),
 			}

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -17,15 +17,14 @@ export class MobileFastlyCachePurger extends GuStack {
 				Conf: new iam.PolicyDocument({
 					statements: [
 						new iam.PolicyStatement({
-							actions: [ 'ssm:GetParametersByPath', 'ssm:GetParameter' ],
-							effect: iam.Effect.ALLOW,
+							actions: [ 'ssm:GetParametersByPath' ],
 							resources: [ `arn:aws:ssm:${scope.region}:${scope.account}:parameter/mobile-fastly-cache-purger/${this.stage}` ]
 						})
 					] }),
 			}
 		})
 
-		new GuLambdaFunction(this, 'mobile-fastly-cache-purger', {
+		const handler = new GuLambdaFunction(this, 'mobile-fastly-cache-purger', {
 			handler: 'PurgerLambda::handleRequest',
 			functionName: `mobile-fastly-cache-purger-cdk-${this.stage}`,
 			timeout: Duration.seconds(60),

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -3,17 +3,31 @@ import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import type { App } from 'aws-cdk-lib';
-import { Duration } from 'aws-cdk-lib';
+import {CfnParameter, Duration} from 'aws-cdk-lib';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
 export class MobileFastlyCachePurger extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
 		super(scope, id, props);
+
+		const fastlyServiceId = new CfnParameter(this, 'FastlyServiceId', {
+			type: 'String',
+			description: 'Id of service to purge',
+		});
+		const fastlyAPIKey = new CfnParameter(this, 'FastlyAPIKey', {
+			type: 'String',
+			description:
+				'API key with purge writes for service with id FastlyServiceId',
+			noEcho: true,
+		});
+
 		new GuLambdaFunction(this, 'mobile-fastly-cache-purger', {
 			handler: 'PurgerLambda::handleRequest',
 			functionName: `mobile-fastly-cache-purger-cdk-${this.stage}`,
 			timeout: Duration.seconds(60),
 			environment: {
+				FastlyServiceId: fastlyServiceId.valueAsString,
+				FastlyAPIKey: fastlyAPIKey.valueAsString,
 				App: 'mobile-fastly-cache-purger',
 				Stack: this.stack,
 				Stage: this.stage,

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -18,7 +18,7 @@ export class MobileFastlyCachePurger extends GuStack {
 					statements: [
 						new iam.PolicyStatement({
 							actions: [ 'ssm:GetParametersByPath' ],
-							resources: [ `arn:aws:ssm:${this.region}:${this.account}:parameter/mobile-fastly-cache-purger/${this.stage}` ]
+							resources: [ `arn:aws:ssm:${this.region}:${this.account}:parameter/cache-purger/${this.stage}` ]
 						})
 					] }),
 			}

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -17,7 +17,8 @@ export class MobileFastlyCachePurger extends GuStack {
 				Conf: new iam.PolicyDocument({
 					statements: [
 						new iam.PolicyStatement({
-							actions: [ 'ssm:GetParameterByPath' ],
+							actions: [ 'ssm:GetParametersByPath', 'ssm:GetParameter' ],
+							effect: iam.Effect.ALLOW,
 							resources: [ `arn:aws:ssm:${scope.region}:${scope.account}:parameter/mobile-fastly-cache-purger/${this.stage}` ]
 						})
 					] }),

--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -1,17 +1,23 @@
+import com.gu.{AppIdentity, AwsIdentity}
+import com.gu.conf.{ConfigurationLoader, SSMConfigurationLocation}
+import com.typesafe.config.{Config => Conf}
+
 case class Config(fastlyServiceId: String, fastlyApiKey: String)
 
 object Config {
 
+  private def fetchConfiguration(): Conf = {
+    val identity = AppIdentity.whoAmI(defaultAppName = "mobile-fastly-cache-purger")
+    ConfigurationLoader.load(identity) {
+      case AwsIdentity(_, _, stage, _) => SSMConfigurationLocation(s"/cache-purger/$stage")
+    }
+  }
+
   def load(): Config = {
     println("Loading facia-purger config...")
 
-    val config = for {
-      fastlyApiKey <- Option(System.getenv("FastlyAPIKey"))
-      fastlyServiceId <- Option(System.getenv("FastlyServiceId"))
-    } yield {
-      Config(fastlyServiceId, fastlyApiKey)
-    }
+    val config = fetchConfiguration()
 
-    config.getOrElse(sys.error("Missing environment variable - FastlyAPIKey & FastlyServiceId must be provided"))
+    Config(config.getString("FastlyServiceId"), config.getString("FastlyAPIKey"))
   }
 }

--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -1,0 +1,17 @@
+case class Config(fastlyServiceId: String, fastlyApiKey: String)
+
+object Config {
+
+  def load(): Config = {
+    println("Loading facia-purger config...")
+
+    val config = for {
+      fastlyApiKey <- Option(System.getenv("FastlyAPIKey"))
+      fastlyServiceId <- Option(System.getenv("FastlyServiceId"))
+    } yield {
+      Config(fastlyServiceId, fastlyApiKey)
+    }
+
+    config.getOrElse(sys.error("Missing environment variable - FastlyAPIKey & FastlyServiceId must be provided"))
+  }
+}

--- a/src/main/scala/PurgerLambda.scala
+++ b/src/main/scala/PurgerLambda.scala
@@ -1,7 +1,41 @@
-import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.events.S3Event
+import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
+import okhttp3._
 
-object PurgerLambda {
-  def handleRequest(context: Context): Unit = {
-    println("Hello World!")
+
+object PurgerLambda extends RequestHandler[S3Event, Boolean] {
+  lazy val httpClient = new OkHttpClient()
+  override def handleRequest(event: S3Event, context: Context): Boolean = {
+
+    println(s"Facia-purger lambda starting up")
+
+    val config = Config.load()
+
+    // OkHttp requires a media type even for an empty POST body
+    val EmptyJsonBody: RequestBody =
+      RequestBody.create("", MediaType.parse("application/json; charset=utf-8"))
+
+    /**
+     * Send a soft purge request to Fastly API.
+     */
+    def sendPurgeRequest(contentId: String = ""): Boolean = {
+      val surrogateKey = "Container/uk/groups/collections/0dd06021-c399-4d40-92da-04055628ac7d"
+      val url = s"https://api.fastly.com/service/${config.fastlyServiceId}/purge/$surrogateKey"
+
+      val request = new Request.Builder()
+        .url(url)
+        .header("Fastly-Key", config.fastlyApiKey)
+        .header("Fastly-Soft-Purge", "1")
+        .post(EmptyJsonBody)
+        .build()
+
+      val response = httpClient.newCall(request).execute()
+      println(s"Sent purge request for content with ID ''. Response from Fastly API: [${response.code}] [${response.body.string}]")
+
+      response.code == 200
+    }
+
+    sendPurgeRequest()
+    true
   }
 }

--- a/src/main/scala/PurgerLambdaLocalRun.scala
+++ b/src/main/scala/PurgerLambdaLocalRun.scala
@@ -1,0 +1,3 @@
+object PurgerLambdaLocalRun extends App {
+  PurgerLambda.handleRequest(null, null)
+}


### PR DESCRIPTION
## What does this change?

This PR adds lamda config as well as relevant policy to the Fastly cache purger lambda 
 <img src="https://github.com/guardian/mobile-fastly-cache-purger/assets/55602675/c0494802-29e4-4dbd-8e9c-cfddeb562a18" width="300px" />

that enable the lambda to access the secrets in the Parameter Store:
 <img src="https://github.com/guardian/mobile-fastly-cache-purger/assets/55602675/a11751b2-4f21-4382-8c10-b4e4d26579eb)" width="300px" />

## How to test

This was deployed to CODE and lambda was successfully tested through the AWS console.
The lambda successfully accessed the parameter store secrets and executed a fastly cached purge.
 <img src="https://github.com/guardian/mobile-fastly-cache-purger/assets/55602675/685c890b-6547-4ad4-a508-e11bdf217059" width="300px" />

