### PR TITLE
Trigger Lambda From Notification

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,5 +27,9 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.0",
   "com.squareup.okhttp3" % "okhttp" % "4.9.2",
-  "com.gu" %% "simple-configuration-ssm" % "1.5.6"
+  "com.gu" %% "simple-configuration-ssm" % "1.5.6",
+  "io.circe" %% "circe-parser" % "0.15.0-M1",
+  "io.circe" %% "circe-core" % "0.15.0-M1",
+  "io.circe" %% "circe-generic" % "0.15.0-M1",
+
 )

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ assembly / assemblyMergeStrategy := {
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.0",
+  "com.amazonaws" % "aws-java-sdk-sqs" % "1.12.205",
   "com.squareup.okhttp3" % "okhttp" % "4.9.2",
   "com.gu" %% "simple-configuration-ssm" % "1.5.6",
   "io.circe" %% "circe-parser" % "0.15.0-M1",

--- a/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
@@ -242,10 +242,44 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "frontsPurgeDlq224A89E8": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-fastly-cache-purger",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-fastly-cache-purger",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
     "frontsPurgeSqsC6BB4572": {
       "DeletionPolicy": "Delete",
       "Properties": {
         "QueueName": "sqs",
+        "RedrivePolicy": {
+          "deadLetterTargetArn": {
+            "Fn::GetAtt": [
+              "frontsPurgeDlq224A89E8",
+              "Arn",
+            ],
+          },
+          "maxReceiveCount": 3,
+        },
         "Tags": [
           {
             "Key": "gu:cdk:version",

--- a/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
@@ -221,6 +221,7 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
             "Value": "TEST",
           },
         ],
+        "VisibilityTimeout": 70,
       },
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",

--- a/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
@@ -171,6 +171,22 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
                 ],
               },
             },
+            {
+              "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueUrl",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "frontsPurgeSqsC6BB4572",
+                  "Arn",
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -186,6 +202,7 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
     "frontsPurgeSqsC6BB4572": {
       "DeletionPolicy": "Delete",
       "Properties": {
+        "QueueName": "sqs",
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -265,6 +282,20 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
+    },
+    "mobilefastlycachepurgerSqsEventSourceMobileFastlyCachePurgerfrontsPurgeSqsE6F58D3DEF06EEF4": {
+      "Properties": {
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "frontsPurgeSqsC6BB4572",
+            "Arn",
+          ],
+        },
+        "FunctionName": {
+          "Ref": "mobilefastlycachepurgerFDB90D2A",
+        },
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
     },
   },
 }

--- a/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
@@ -270,7 +270,6 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
     "frontsPurgeSqsC6BB4572": {
       "DeletionPolicy": "Delete",
       "Properties": {
-        "QueueName": "sqs",
         "RedrivePolicy": {
           "deadLetterTargetArn": {
             "Fn::GetAtt": [

--- a/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
@@ -37,6 +37,49 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
             "PolicyDocument": {
               "Statement": [
                 {
+                  "Action": "logs:CreateLogGroup",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:aws:logs:eu-west-1:",
+                        {
+                          "Ref": "AWS::AccountId",
+                        },
+                        ":*",
+                      ],
+                    ],
+                  },
+                },
+                {
+                  "Action": [
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:aws:logs:eu-west-1:",
+                        {
+                          "Ref": "AWS::AccountId",
+                        },
+                        ":log-group:/aws/lambda/*:*",
+                      ],
+                    ],
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "logs",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
                   "Action": "ssm:GetParametersByPath",
                   "Effect": "Allow",
                   "Resource": {

--- a/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
@@ -183,6 +183,31 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "frontsPurgeSqsC6BB4572": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-fastly-cache-purger",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-fastly-cache-purger",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
     "mobilefastlycachepurgerFDB90D2A": {
       "DependsOn": [
         "ExecutionRoleDefaultPolicyA5B92313",

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -16,6 +16,17 @@ export class MobileFastlyCachePurger extends GuStack {
 			assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
 			path: "/",
 			inlinePolicies: {
+				logs: new iam.PolicyDocument({
+					statements: [
+						new iam.PolicyStatement({
+							actions: [ 'logs:CreateLogGroup' ],
+							resources: [ `arn:aws:logs:eu-west-1:${this.account}:*` ]
+						}),
+						new iam.PolicyStatement({
+							actions: [ 'logs:CreateLogStream', 'logs:PutLogEvents' ],
+							resources: [ `arn:aws:logs:eu-west-1:${this.account}:log-group:/aws/lambda/*:*` ]
+						})
+					] }),
 				Conf: new iam.PolicyDocument({
 					statements: [
 						new iam.PolicyStatement({

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -4,8 +4,9 @@ import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import type { App } from 'aws-cdk-lib';
 import {Duration} from 'aws-cdk-lib';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
-import * as iam from 'aws-cdk-lib/aws-iam'
+import * as iam from 'aws-cdk-lib/aws-iam';
 import * as sqs from 'aws-cdk-lib/aws-sqs';
+import * as lambdaEventSources from 'aws-cdk-lib/aws-lambda-event-sources';
 
 export class MobileFastlyCachePurger extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
@@ -40,6 +41,14 @@ export class MobileFastlyCachePurger extends GuStack {
 			role: executionRole,
 		});
 
-		const queue = new sqs.Queue(this, "frontsPurgeSqs");
+		const queue = new sqs.Queue(this, "frontsPurgeSqs", {
+			queueName: 'sqs',
+		});
+
+		const eventSource = new lambdaEventSources.SqsEventSource(queue);
+
+		handler.addEventSource(eventSource);
+
+
 	}
 }

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -12,7 +12,7 @@ export class MobileFastlyCachePurger extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
 		super(scope, id, props);
 
-		const executionRole = new iam.Role(this, 'ExecutionRole', {
+		const executionRole: iam.Role = new iam.Role(this, 'ExecutionRole', {
 			assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
 			path: "/",
 			inlinePolicies: {
@@ -37,7 +37,7 @@ export class MobileFastlyCachePurger extends GuStack {
 			}
 		})
 
-		const handler = new GuLambdaFunction(this, 'mobile-fastly-cache-purger', {
+		const handler: GuLambdaFunction = new GuLambdaFunction(this, 'mobile-fastly-cache-purger', {
 			handler: 'PurgerLambda::handleRequest',
 			functionName: `mobile-fastly-cache-purger-cdk-${this.stage}`,
 			timeout: Duration.seconds(60),
@@ -54,16 +54,15 @@ export class MobileFastlyCachePurger extends GuStack {
 
 		const dlq: sqs.Queue = new sqs.Queue(this, "frontsPurgeDlq")
 
-		const queue = new sqs.Queue(this, "frontsPurgeSqs", {
-			queueName: 'sqs',
-			visibilityTimeout: Duration.seconds(70),
+		const queue: sqs.Queue = new sqs.Queue(this, "frontsPurgeSqs", {
+			visibilityTimeout: Duration.seconds(70), 	//default for a queue is 30s, and the lambda is 60s
 			deadLetterQueue: {
 				maxReceiveCount: 3,
 				queue: dlq,
 			}
 		});
 
-		const eventSource = new lambdaEventSources.SqsEventSource(queue);
+		const eventSource: lambdaEventSources.SqsEventSource = new lambdaEventSources.SqsEventSource(queue);
 
 		handler.addEventSource(eventSource);
 

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -52,9 +52,15 @@ export class MobileFastlyCachePurger extends GuStack {
 			role: executionRole,
 		});
 
+		const dlq: sqs.Queue = new sqs.Queue(this, "frontsPurgeDlq")
+
 		const queue = new sqs.Queue(this, "frontsPurgeSqs", {
 			queueName: 'sqs',
 			visibilityTimeout: Duration.seconds(70),
+			deadLetterQueue: {
+				maxReceiveCount: 3,
+				queue: dlq,
+			}
 		});
 
 		const eventSource = new lambdaEventSources.SqsEventSource(queue);

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -43,6 +43,7 @@ export class MobileFastlyCachePurger extends GuStack {
 
 		const queue = new sqs.Queue(this, "frontsPurgeSqs", {
 			queueName: 'sqs',
+			visibilityTimeout: Duration.seconds(70),
 		});
 
 		const eventSource = new lambdaEventSources.SqsEventSource(queue);

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -5,6 +5,7 @@ import type { App } from 'aws-cdk-lib';
 import {Duration} from 'aws-cdk-lib';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import * as iam from 'aws-cdk-lib/aws-iam'
+import * as sqs from 'aws-cdk-lib/aws-sqs';
 
 export class MobileFastlyCachePurger extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
@@ -38,5 +39,7 @@ export class MobileFastlyCachePurger extends GuStack {
 			fileName: `mobile-fastly-cache-purger.jar`,
 			role: executionRole,
 		});
+
+		const queue = new sqs.Queue(this, "frontsPurgeSqs");
 	}
 }

--- a/src/main/scala/PurgeEvent.scala
+++ b/src/main/scala/PurgeEvent.scala
@@ -9,6 +9,7 @@ object PressJob {
   implicit val derivedDecoder: Decoder[PressJob] = deriveDecoder[PressJob]
 
   def toPressJob(input: String): Option[PressJob] = {
+    println(s"decode: ${decode(input)}")
     decode(input).toOption
   }
 }

--- a/src/main/scala/PurgeEvent.scala
+++ b/src/main/scala/PurgeEvent.scala
@@ -1,0 +1,15 @@
+import io.circe._
+import io.circe.generic.semiauto._
+import io.circe.parser._
+
+object PurgeEvent {}
+
+object PressJob {
+
+  implicit val derivedDecoder: Decoder[PressJob] = deriveDecoder[PressJob]
+
+  def toPressJob(input: String): Option[PressJob] = {
+    decode(input).toOption
+  }
+}
+case class PressJob(path: String, pressType: String)

--- a/src/main/scala/PurgeEvent.scala
+++ b/src/main/scala/PurgeEvent.scala
@@ -9,7 +9,6 @@ object PressJob {
   implicit val derivedDecoder: Decoder[PressJob] = deriveDecoder[PressJob]
 
   def toPressJob(input: String): Option[PressJob] = {
-    println(s"decode: ${decode(input)}")
     decode(input).toOption
   }
 }

--- a/src/main/scala/PurgerLambda.scala
+++ b/src/main/scala/PurgerLambda.scala
@@ -9,10 +9,15 @@ object PurgerLambda extends RequestHandler[SQSEvent, Boolean] {
   lazy val httpClient = new OkHttpClient()
   override def handleRequest(event: SQSEvent, context: Context): Boolean = {
 
-    println("event: ", event)
-    val records: List[PressJob] = event.getRecords.asScala.toList.flatMap(r => PressJob.toPressJob(r.getBody))
-    println("records: ", records)
-    val frontPath: String = records.head.path
+    val scalaRecords = event.getRecords.asScala.toList
+    println("scalaRecord: ", scalaRecords)
+    val pressJobs = scalaRecords.flatMap(r => {
+      println("r: ", r)
+      print(s"r body: ${r.getBody}")
+      PressJob.toPressJob(r.getBody)
+    })
+    println("pressJobs: ", pressJobs)
+    val frontPath: String = pressJobs.head.path
     println("frontPath: ", frontPath)
 
     println(s"Facia-purger lambda starting up")

--- a/src/main/scala/PurgerLambda.scala
+++ b/src/main/scala/PurgerLambda.scala
@@ -10,17 +10,11 @@ object PurgerLambda extends RequestHandler[SQSEvent, Boolean] {
   override def handleRequest(event: SQSEvent, context: Context): Boolean = {
 
     val scalaRecords = event.getRecords.asScala.toList
-    println("scalaRecord: ", scalaRecords)
     val pressJobs = scalaRecords.flatMap(r => {
-      println("r: ", r)
-      print(s"r body: ${r.getBody}")
       PressJob.toPressJob(r.getBody)
     })
-    println("pressJobs: ", pressJobs)
     val frontPath: String = pressJobs.head.path
-    println("frontPath: ", frontPath)
 
-    println(s"Facia-purger lambda starting up")
 
     val config = Config.load()
 

--- a/src/main/scala/PurgerLambda.scala
+++ b/src/main/scala/PurgerLambda.scala
@@ -10,7 +10,9 @@ object PurgerLambda extends RequestHandler[SQSEvent, Boolean] {
   override def handleRequest(event: SQSEvent, context: Context): Boolean = {
 
     val records: List[PressJob] = event.getRecords.asScala.toList.flatMap(r => PressJob.toPressJob(r.getBody))
+    println("records: ", records)
     val frontPath: String = records.head.path
+    println("frontPath: ", frontPath)
 
     println(s"Facia-purger lambda starting up")
 

--- a/src/main/scala/PurgerLambda.scala
+++ b/src/main/scala/PurgerLambda.scala
@@ -9,6 +9,7 @@ object PurgerLambda extends RequestHandler[SQSEvent, Boolean] {
   lazy val httpClient = new OkHttpClient()
   override def handleRequest(event: SQSEvent, context: Context): Boolean = {
 
+    println("event: ", event)
     val records: List[PressJob] = event.getRecords.asScala.toList.flatMap(r => PressJob.toPressJob(r.getBody))
     println("records: ", records)
     val frontPath: String = records.head.path

--- a/src/main/scala/PurgerLambda.scala
+++ b/src/main/scala/PurgerLambda.scala
@@ -1,11 +1,16 @@
-import com.amazonaws.services.lambda.runtime.events.S3Event
+import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import okhttp3._
 
+import scala.jdk.CollectionConverters._
 
-object PurgerLambda extends RequestHandler[S3Event, Boolean] {
+
+object PurgerLambda extends RequestHandler[SQSEvent, Boolean] {
   lazy val httpClient = new OkHttpClient()
-  override def handleRequest(event: S3Event, context: Context): Boolean = {
+  override def handleRequest(event: SQSEvent, context: Context): Boolean = {
+
+    val records = event.getRecords.asScala.toList
+    println(records)
 
     println(s"Facia-purger lambda starting up")
 

--- a/src/main/scala/PurgerLambdaLocalRun.scala
+++ b/src/main/scala/PurgerLambdaLocalRun.scala
@@ -1,3 +1,19 @@
+import com.amazonaws.services.lambda.runtime.events.SQSEvent
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
+
+import java.time.Instant
+import scala.jdk.CollectionConverters._
+
 object PurgerLambdaLocalRun extends App {
-  PurgerLambda.handleRequest(null, null)
+
+  val sqsEvent: SQSEvent = {
+    val event = new SQSEvent()
+    val sqsMessage = new SQSMessage()
+    sqsMessage.setBody("{\"path\":\"app/front-mss\",\"pressType\":\"draft\",\"creationTime\":1690799830981,\"forceConfigUpdate\":false}")
+    sqsMessage.setAttributes((Map("SentTimestamp" -> s"${Instant.now.toEpochMilli}").asJava))
+    event.setRecords(List(sqsMessage).asJava)
+    event
+  }
+
+  PurgerLambda.handleRequest(sqsEvent, null)
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- Creates a new SQS queue (`mobile-fastly-cache-purger-CODE-mobile-fastl-frontsPurgeSqsC6BB4572-66o3qkXTHg6y`) and dead letter queue (`mobile-fastly-cache-purger-CODE-mobile-fastl-frontsPurgeDlq224A89E8-yYrPxb7IC9WV`) using CDK
- Adds logging policies to the `mobile-fastly-cache-purger-lambda`
- Adds SQS eventSource to the lambda
- Adds the logic for reading and parsing messages from the queue

## How to test

Locally, this was tested using the Local Run function with a hardcoded json message.

The code was also deployed to code and tested using the AWS Console:
1) Queues created:
<img width="400" alt="Screenshot 2023-08-03 at 14 29 04" src="https://github.com/guardian/mobile-fastly-cache-purger/assets/55602675/ef4f7165-9447-4f75-8511-48de11ea7a77">

2) Queue will trigger the lambda:
<img width="400" alt="Screenshot 2023-08-03 at 14 54 54" src="https://github.com/guardian/mobile-fastly-cache-purger/assets/55602675/679b1182-d976-483e-a896-3bb7c4ce9bbd">

3) Message sent to the queue:
<img width="400" alt="Screenshot 2023-08-03 at 14 29 41" src="https://github.com/guardian/mobile-fastly-cache-purger/assets/55602675/fc843a88-d2fd-462e-9f4a-b7630aa70795">

4) Lambda was triggered and sent the fastly purge request:
<img width="400" alt="Screenshot 2023-08-03 at 14 31 05" src="https://github.com/guardian/mobile-fastly-cache-purger/assets/55602675/2f559ffc-ba52-4548-a0f4-729c9db9f13f">


