### PR TITLE
Filter out press jobs of type draft

### DIFF
--- a/src/main/scala/PurgerLambda.scala
+++ b/src/main/scala/PurgerLambda.scala
@@ -37,11 +37,13 @@ object PurgerLambda extends RequestHandler[SQSEvent, Boolean] {
       })
     // Currently we do not expect to receive more than one front path in a message, but we want to anticipate
     // for this changing in the future
-    val frontPathList: List[String] = pressJobs
-      .filter(_.pressType != "Draft") // We are not interested in draft changes
-      .map(_.path)
+    val frontPathList: List[String] = {
+      println(pressJobs.head)
+      pressJobs
+        .filter(_.pressType != "Draft") // We are not interested in draft changes
+        .map(_.path)
+    }
 
-    println(s"front path list $frontPathList")
     // Set up credentials to get the config.json from the CMS fronts S3 bucket
     val purgerConfig: Config = Config.load()
     val provider = new AWSCredentialsProviderChain(

--- a/src/main/scala/PurgerLambda.scala
+++ b/src/main/scala/PurgerLambda.scala
@@ -37,12 +37,10 @@ object PurgerLambda extends RequestHandler[SQSEvent, Boolean] {
       })
     // Currently we do not expect to receive more than one front path in a message, but we want to anticipate
     // for this changing in the future
-    val frontPathList: List[String] = {
-      println(pressJobs.head)
+    val frontPathList: List[String] =
       pressJobs
         .filter(_.pressType != "draft") // We are not interested in draft changes
         .map(_.path)
-    }
 
     // Set up credentials to get the config.json from the CMS fronts S3 bucket
     val purgerConfig: Config = Config.load()

--- a/src/main/scala/PurgerLambda.scala
+++ b/src/main/scala/PurgerLambda.scala
@@ -40,7 +40,7 @@ object PurgerLambda extends RequestHandler[SQSEvent, Boolean] {
     val frontPathList: List[String] = {
       println(pressJobs.head)
       pressJobs
-        .filter(_.pressType != "Draft") // We are not interested in draft changes
+        .filter(_.pressType != "draft") // We are not interested in draft changes
         .map(_.path)
     }
 

--- a/src/main/scala/PurgerLambda.scala
+++ b/src/main/scala/PurgerLambda.scala
@@ -37,8 +37,11 @@ object PurgerLambda extends RequestHandler[SQSEvent, Boolean] {
       })
     // Currently we do not expect to receive more than one front path in a message, but we want to anticipate
     // for this changing in the future
-    val frontPathList: List[String] = pressJobs.map(_.path)
+    val frontPathList: List[String] = pressJobs
+      .filter(_.pressType != "Draft") // We are not interested in draft changes
+      .map(_.path)
 
+    println(s"front path list $frontPathList")
     // Set up credentials to get the config.json from the CMS fronts S3 bucket
     val purgerConfig: Config = Config.load()
     val provider = new AWSCredentialsProviderChain(


### PR DESCRIPTION
## What does this change?

### How do draft/live updates work in the fronts tool? 
According to the Content Production team:
_The events on your SNS topic are being fired in the press handler. This is called whenever any draft changes happen. When user hits Launch (in the fronts tool), this generates both a draft AND a live press event. (This is true for both CODE and PROD versions of the fronts tool)._

We would like our cache purger lambda to not send a purge request for draft updates in the fronts tool in order to reduce the number of cache purge requests sent to Fastly.

## How to test

The change was deployed to code and we could see that:

-  Draft live press events are being filtered out
- Purge requests are not being sent for draft events.

<img width="1380" alt="Screenshot 2023-11-20 at 14 32 12" src="https://github.com/guardian/mobile-fastly-cache-purger/assets/55602675/0ccc359f-f69c-4a04-b397-55eb5739887f">
