### PR TITLE
Provision a PROD stage

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -8,3 +8,9 @@ new MobileFastlyCachePurger(app, 'MobileFastlyCachePurger-CODE', {
 	stack: 'mobile-fastly-cache-purger',
 	stage: 'CODE',
 });
+
+new MobileFastlyCachePurger(app, 'MobileFastlyCachePurger-PROD', {
+	env: { region: 'eu-west-1' },
+	stack: 'mobile-fastly-cache-purger',
+	stage: 'PROD',
+});

--- a/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
@@ -115,7 +115,7 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
                 {
                   "Action": "sts:AssumeRole",
                   "Effect": "Allow",
-                  "Resource": "arn:aws:iam::163592447864:role/facia-TEST-MobileFastlyCachePurger/StorageConsumerRole-1R9GQEVJIM323",
+                  "Resource": "arn:aws:iam::163592447864:role/facia-TEST-StorageConsumerRole-1R9GQEVJIM323",
                 },
               ],
               "Version": "2012-10-17",

--- a/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
@@ -104,6 +104,19 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
             },
             "PolicyName": "Conf",
           },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "sts:AssumeRole",
+                  "Effect": "Allow",
+                  "Resource": "arn:aws:iam::163592447864:role/facia-TEST-StorageConsumerRole-1R9GQEVJIM323",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "Assume",
+          },
         ],
         "Tags": [
           {

--- a/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
@@ -4,6 +4,7 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [
+      "GuStringParameter",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
     ],
@@ -14,6 +15,10 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "StorageConsumerRole1R9GQEVJIM323": {
+      "Description": "ARN of the CMS fronts cross-account role",
+      "Type": "String",
     },
   },
   "Resources": {
@@ -103,6 +108,19 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
               "Version": "2012-10-17",
             },
             "PolicyName": "Conf",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "sts:AssumeRole",
+                  "Effect": "Allow",
+                  "Resource": "arn:aws:iam::163592447864:role/facia-TEST-MobileFastlyCachePurger/StorageConsumerRole-1R9GQEVJIM323",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "Assume",
           },
         ],
         "Tags": [
@@ -325,7 +343,7 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
               {
                 "Ref": "AWS::Region",
               },
-              ":163592447864:facia-TEST-FrontsUpdateSNSTopic-RepwK3g95V3w",
+              ":163592447864:facia-TEST-FrontsUpdateSNSTopic-kWN6oX2kvOmI",
             ],
           ],
         },
@@ -348,7 +366,7 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
                         {
                           "Ref": "AWS::Region",
                         },
-                        ":163592447864:facia-TEST-FrontsUpdateSNSTopic-RepwK3g95V3w",
+                        ":163592447864:facia-TEST-FrontsUpdateSNSTopic-kWN6oX2kvOmI",
                       ],
                     ],
                   },

--- a/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
@@ -4,7 +4,6 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [
-      "GuStringParameter",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
     ],
@@ -15,10 +14,6 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
-    },
-    "StorageConsumerRole1R9GQEVJIM323": {
-      "Description": "ARN of the CMS fronts cross-account role",
-      "Type": "String",
     },
   },
   "Resources": {
@@ -108,19 +103,6 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
               "Version": "2012-10-17",
             },
             "PolicyName": "Conf",
-          },
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": "sts:AssumeRole",
-                  "Effect": "Allow",
-                  "Resource": "arn:aws:iam::163592447864:role/facia-TEST-StorageConsumerRole-1R9GQEVJIM323",
-                },
-              ],
-              "Version": "2012-10-17",
-            },
-            "PolicyName": "Assume",
           },
         ],
         "Tags": [

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -16,11 +16,11 @@ export class MobileFastlyCachePurger extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
 		super(scope, id, props);
 
-		const faciaID = this.stage == "CODE" ? "StorageConsumerRole-1JWVQ2NTELFT7" : "StorageConsumerRole-1R9GQEVJIM323";
-
-		const faciaRole = new GuStringParameter(this, faciaID, {
-			description: "ARN of the CMS fronts cross-account role",
-		});
+		// const faciaID = this.stage == "CODE" ? "StorageConsumerRole-1JWVQ2NTELFT7" : "StorageConsumerRole-1R9GQEVJIM323";
+		//
+		// const faciaRole = new GuStringParameter(this, faciaID, {
+		// 	description: "ARN of the CMS fronts cross-account role",
+		// });
 
 		const executionRole: iam.Role = new iam.Role(this, 'ExecutionRole', {
 			assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
@@ -44,14 +44,14 @@ export class MobileFastlyCachePurger extends GuStack {
 							resources: [ `arn:aws:ssm:${this.region}:${this.account}:parameter/cache-purger/${this.stage}` ]
 						})
 					] }),
-				Assume: new iam.PolicyDocument({
-					statements: [
-						new iam.PolicyStatement({
-							actions: ['sts:AssumeRole'],
-							resources: [`arn:aws:iam::${GuardianAwsAccounts.CMSFronts}:role/facia-${this.stage}-${faciaRole.id}`]
-						})
-					]
-				})
+				// Assume: new iam.PolicyDocument({
+				// 	statements: [
+				// 		new iam.PolicyStatement({
+				// 			actions: ['sts:AssumeRole'],
+				// 			resources: [`arn:aws:iam::${GuardianAwsAccounts.CMSFronts}:role/facia-${this.stage}-${faciaRole.id}`]
+				// 		})
+				// 	]
+				// })
 			}
 		})
 

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -18,9 +18,6 @@ export class MobileFastlyCachePurger extends GuStack {
 
 		const faciaID = this.stage == "CODE" ? "StorageConsumerRole-1JWVQ2NTELFT7" : "StorageConsumerRole-1R9GQEVJIM323";
 
-		// const faciaRole = new GuStringParameter(this, faciaID, {
-		// 	description: "ARN of the CMS fronts cross-account role",
-		// });
 
 		const executionRole: iam.Role = new iam.Role(this, 'ExecutionRole', {
 			assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -16,8 +16,8 @@ export class MobileFastlyCachePurger extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
 		super(scope, id, props);
 
-		// const faciaID = this.stage == "CODE" ? "StorageConsumerRole-1JWVQ2NTELFT7" : "StorageConsumerRole-1R9GQEVJIM323";
-		//
+		const faciaID = this.stage == "CODE" ? "StorageConsumerRole-1JWVQ2NTELFT7" : "StorageConsumerRole-1R9GQEVJIM323";
+
 		// const faciaRole = new GuStringParameter(this, faciaID, {
 		// 	description: "ARN of the CMS fronts cross-account role",
 		// });
@@ -44,14 +44,14 @@ export class MobileFastlyCachePurger extends GuStack {
 							resources: [ `arn:aws:ssm:${this.region}:${this.account}:parameter/cache-purger/${this.stage}` ]
 						})
 					] }),
-				// Assume: new iam.PolicyDocument({
-				// 	statements: [
-				// 		new iam.PolicyStatement({
-				// 			actions: ['sts:AssumeRole'],
-				// 			resources: [`arn:aws:iam::${GuardianAwsAccounts.CMSFronts}:role/facia-${this.stage}-${faciaRole.id}`]
-				// 		})
-				// 	]
-				// })
+				Assume: new iam.PolicyDocument({
+					statements: [
+						new iam.PolicyStatement({
+							actions: ['sts:AssumeRole'],
+							resources: [`arn:aws:iam::${GuardianAwsAccounts.CMSFronts}:role/facia-${this.stage}-${faciaID}`]
+						})
+					]
+				})
 			}
 		})
 

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -1,5 +1,5 @@
 import { GuardianAwsAccounts } from '@guardian/private-infrastructure-config';
-import {GuStackProps, GuStringParameter} from '@guardian/cdk/lib/constructs/core';
+import {GuStackProps} from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import type { App } from 'aws-cdk-lib';

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -40,12 +40,6 @@ export class MobileFastlyCachePurger extends GuStack {
 			}
 		})
 
-		//User: arn:aws:sts::201359054765:assumed-role/StackSet-RiffRaffAccess-f-RiffRaffCloudformationEx-1XQEWZT2RFY7F/AWSCloudFormation
-		// is not authorized to perform: SNS:Subscribe on resource:
-		// arn:aws:sns:eu-west-1:163592447864:facia-PROD-FrontsUpdateSNSTopic-RepwK3g95V3w
-		// because no resource-based policy allows the SNS:Subscribe action
-		// (Service: AmazonSNS; Status Code: 403; Error Code: AuthorizationError; Request ID: 9cc90544-4e0d-5b5b-b02a-589d04a26cce; Proxy: null)
-
 		const handler: GuLambdaFunction = new GuLambdaFunction(this, 'mobile-fastly-cache-purger', {
 			handler: 'PurgerLambda::handleRequest',
 			functionName: `mobile-fastly-cache-purger-cdk-${this.stage}`,

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -40,6 +40,12 @@ export class MobileFastlyCachePurger extends GuStack {
 			}
 		})
 
+		//User: arn:aws:sts::201359054765:assumed-role/StackSet-RiffRaffAccess-f-RiffRaffCloudformationEx-1XQEWZT2RFY7F/AWSCloudFormation
+		// is not authorized to perform: SNS:Subscribe on resource:
+		// arn:aws:sns:eu-west-1:163592447864:facia-PROD-FrontsUpdateSNSTopic-RepwK3g95V3w
+		// because no resource-based policy allows the SNS:Subscribe action
+		// (Service: AmazonSNS; Status Code: 403; Error Code: AuthorizationError; Request ID: 9cc90544-4e0d-5b5b-b02a-589d04a26cce; Proxy: null)
+
 		const handler: GuLambdaFunction = new GuLambdaFunction(this, 'mobile-fastly-cache-purger', {
 			handler: 'PurgerLambda::handleRequest',
 			functionName: `mobile-fastly-cache-purger-cdk-${this.stage}`,
@@ -65,7 +71,8 @@ export class MobileFastlyCachePurger extends GuStack {
 			}
 		});
 
-		const frontsUpdateTopicName = "FrontsUpdateSNSTopic-RepwK3g95V3w";
+		const frontsUpdateTopicName=
+			this.stage == "CODE" ? "FrontsUpdateSNSTopic-RepwK3g95V3w" : "FrontsUpdateSNSTopic-kWN6oX2kvOmI";
 
 		const frontsUpdateTopic = sns.Topic.fromTopicArn(
 			this,

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -48,7 +48,7 @@ export class MobileFastlyCachePurger extends GuStack {
 					statements: [
 						new iam.PolicyStatement({
 							actions: ['sts:AssumeRole'],
-							resources: [`arn:aws:iam::${GuardianAwsAccounts.CMSFronts}:role/facia-${this.stage}-${faciaRole}`]
+							resources: [`arn:aws:iam::${GuardianAwsAccounts.CMSFronts}:role/facia-${this.stage}-${faciaRole.id}`]
 						})
 					]
 				})


### PR DESCRIPTION
## What does this change?

Having successfully implemented the CODE version of the mobile Fastly cache purger, this PR provisions a PROD stage for the purger.

Changes:

-  add PROD stage to the lambda CDK
- select the PROD or CODE SNS topic, depending on environment
- create two new parameters in the Parameter Store: Fastly PROD service ID and Fastly PROD API Key
- add sts:AssumeRole policy to the lambda policies
- set up continuous deployment in RiffRaff

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
This has been deployed to PROD, and the stack has been created successfully:
<img width="500" alt="Screenshot 2023-11-28 at 12 30 40" src="https://github.com/guardian/mobile-fastly-cache-purger/assets/55602675/5453a276-57c6-4b44-b9c6-5cf010639c3c">

The lambda is being invoked successfully and sending purge requests to Fastly:
<img width="500" alt="Screenshot 2023-11-28 at 12 31 18" src="https://github.com/guardian/mobile-fastly-cache-purger/assets/55602675/7dd8e136-e4e6-42ab-b97f-ab412841ddcd">
<img width="500" alt="Screenshot 2023-11-28 at 12 32 20" src="https://github.com/guardian/mobile-fastly-cache-purger/assets/55602675/54482d84-d916-4b5d-b056-5668be361388">