### PR TITLE
Use jest to mask account number in snapshot

### DIFF
--- a/cdk/jest.config.js
+++ b/cdk/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    setupFilesAfterEnv: ["./jest.setup.js"],
+    transformIgnorePatterns: ["node_modules/(?!@guardian/private-infrastructure-config)"],
+    testMatch: ["<rootDir>/lib/**/*.test.ts"],
+    transform: {"^.+\\.tsx?$": "ts-jest"},
+};
+

--- a/cdk/jest.setup.js
+++ b/cdk/jest.setup.js
@@ -1,1 +1,3 @@
 jest.mock("@guardian/cdk/lib/constants/tracking-tag");
+jest.mock("@guardian/private-infrastructure-config");
+

--- a/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
@@ -325,7 +325,7 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
               {
                 "Ref": "AWS::Region",
               },
-              ":163592447864:facia-TEST-FrontsUpdateSNSTopic-RepwK3g95V3w",
+              ":000000000020:facia-TEST-FrontsUpdateSNSTopic-RepwK3g95V3w",
             ],
           ],
         },
@@ -348,7 +348,7 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
                         {
                           "Ref": "AWS::Region",
                         },
-                        ":163592447864:facia-TEST-FrontsUpdateSNSTopic-RepwK3g95V3w",
+                        ":000000000020:facia-TEST-FrontsUpdateSNSTopic-RepwK3g95V3w",
                       ],
                     ],
                   },

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -30,17 +30,6 @@
     "typescript": "~4.9.5"
   },
   "prettier": "@guardian/prettier",
-  "jest": {
-    "testMatch": [
-      "<rootDir>/lib/**/*.test.ts"
-    ],
-    "transform": {
-      "^.+\\.tsx?$": "ts-jest"
-    },
-    "setupFilesAfterEnv": [
-      "./jest.setup.js"
-    ]
-  },
   "eslintConfig": {
     "root": true,
     "env": {


### PR DESCRIPTION
## What does this change?

The DevEx team have recommended using jest to mask the account number in the snapshot.
Following the steps outlined here https://github.com/guardian/private-infrastructure-config?tab=readme-ov-file#using-with-jest seems to have done the trick.
