### PR TITLE
Bump simple-configuration-ssm to 1.5.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sns" % "1.12.559",
   "com.amazonaws" % "aws-java-sdk-sts" % "1.12.576",
   "com.squareup.okhttp3" % "okhttp" % "4.9.2",
-  "com.gu" %% "simple-configuration-ssm" % "1.5.6",
+  "com.gu" %% "simple-configuration-ssm" % "1.5.7",
   "io.circe" %% "circe-parser" % "0.15.0-M1",
   "io.circe" %% "circe-core" % "0.15.0-M1",
   "io.circe" %% "circe-generic" % "0.15.0-M1",

--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -24,7 +24,7 @@ object Config {
     }
 
     ConfigurationLoader.load(identity, credentials) {
-      case AwsIdentity(_, stack, stage, region) => SSMConfigurationLocation(s"/cache-purger/$stage/$stack", region)
+      case AwsIdentity(_, _, stage, region) => SSMConfigurationLocation(s"/cache-purger/$stage", region)
     }
   }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Because of [this jira ticket
](https://theguardian.atlassian.net/browse/LIVE-6073)


We want to bump this library to 1.5.7 so that we can fix some vulnerabilities in `mobile-logstash-encoder` but it requires a code change. 

## Testing

I deployed the lambda to CODE and changed a front via the fronts tool. I observed that the lambda executed successfully.

<img width="1302" alt="image" src="https://github.com/guardian/mobile-fastly-cache-purger/assets/102960825/cb798552-3837-4b3e-80f0-80dd77da958d">
