### PR TITLE
Revert "chore(deps): Non-AWS dependency updates"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-parser" % "0.15.0-M1",
   "io.circe" %% "circe-core" % "0.15.0-M1",
   "io.circe" %% "circe-generic" % "0.15.0-M1",
-  "com.gu" %% "fapi-client-play28" % "8.0.0",
+  "com.gu" %% "fapi-client-play28" % "7.0.0",
   "org.slf4j" % "slf4j-api" % "2.0.13",
   "org.slf4j" % "slf4j-simple" % "2.0.13",
  "io.netty" % "netty-codec-http2" % "4.1.111.Final"


### PR DESCRIPTION
Reverts guardian/mobile-fastly-cache-purger#54

It exceeds the maximum size of the lambda packaged as a ZIP / JAR archive.  We will have a separate ticket to look at this size issue.