### PR TITLE
Pin fapi-client-play28 to 7.0.0

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,5 @@
+
+# Pin fapi-client-play28 to 7.0.0.  The lambda hit the maximum archive size limit of 250 MB 
+# when this library was bumped to 8.0.0.  We will look to resolve this archive size issue in
+# a separate ticket.
+updates.pin  = [ { groupId = "com.gu", artifactId="fapi-client-play28", version = "7.0.0" } ]


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The lambda hit the maximum size limit of JAR archives in AWS lambda, which is 250MB, when we bumped the library `fapi-client-play28` to 8.0.0.

This pull request pins this library to 7.0.0, which we are currently using, so that this issue does not block scala-steward from keeping other non-AWS dependencies updated.
