### PR TITLE
Switch on docker version

### DIFF
--- a/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
@@ -453,20 +453,6 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "mobilefastlycachepurgerSqsEventSourceMobileFastlyCachePurgerfrontsPurgeSqsE6F58D3DEF06EEF4": {
-      "Properties": {
-        "EventSourceArn": {
-          "Fn::GetAtt": [
-            "frontsPurgeSqsC6BB4572",
-            "Arn",
-          ],
-        },
-        "FunctionName": {
-          "Ref": "mobilefastlycachepurgerFDB90D2A",
-        },
-      },
-      "Type": "AWS::Lambda::EventSourceMapping",
-    },
     "mobilefastlycachepurgerv23E8BE308": {
       "DependsOn": [
         "ExecutionRoleDefaultPolicyA5B92313",
@@ -558,6 +544,20 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
+    },
+    "mobilefastlycachepurgerv2SqsEventSourceMobileFastlyCachePurgerfrontsPurgeSqsE6F58D3DCF878697": {
+      "Properties": {
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "frontsPurgeSqsC6BB4572",
+            "Arn",
+          ],
+        },
+        "FunctionName": {
+          "Ref": "mobilefastlycachepurgerv23E8BE308",
+        },
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
     },
   },
 }

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -61,7 +61,7 @@ export class MobileFastlyCachePurger extends GuStack {
 			}
 		})
 
-		const handler: GuLambdaFunction = new GuLambdaFunction(this, 'mobile-fastly-cache-purger', {
+		new GuLambdaFunction(this, 'mobile-fastly-cache-purger', {
 			handler: 'PurgerLambda::handleRequest',
 			functionName: `mobile-fastly-cache-purger-cdk-${this.stage}`,
 			timeout: Duration.seconds(60),
@@ -78,7 +78,7 @@ export class MobileFastlyCachePurger extends GuStack {
 
 		const imageRepositoryArn = Fn.importValue('mobile-fastly-cache-purger-repository-arn')
 		const imageRepositoryName = Fn.importValue('mobile-fastly-cache-purger-repository-name')
-		new GuLambdaDockerFunction(this, 'mobile-fastly-cache-purger-v2', {
+		const handler = new GuLambdaDockerFunction(this, 'mobile-fastly-cache-purger-v2', {
 			functionName: `mobile-fastly-cache-purger-cdk-${this.stage}-v2`,
 			timeout: Duration.seconds(60),
 			environment: {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This points the SQS event to the new instance of the lambda function which is now running with a docker image instead of the soon to be deprecated lambda function running in Java. 

## How to test
Tested in CODE that publishing a front causes a purge request to fastly to be sent

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
