### PR TITLE
Deprecate old lambda

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,15 +1,9 @@
 import 'source-map-support/register';
 import { GuRootExperimental } from '@guardian/cdk/lib/experimental/constructs/root';
-import {EnvironmentAgnosticResources} from "../lib/environment-agnostic-resources";
 import { MobileFastlyCachePurger } from '../lib/mobile-fastly-cache-purger';
 
 const app = new GuRootExperimental();
 
-new EnvironmentAgnosticResources(app, 'EnvironmentAgnosticResources', {
-	env: { region: 'eu-west-1' },
-	stack: 'mobile-fastly-cache-purger',
-	stage: 'CODE'
-})
 new MobileFastlyCachePurger(app, 'MobileFastlyCachePurger-CODE', {
 	env: { region: 'eu-west-1' },
 	stack: 'mobile-fastly-cache-purger',

--- a/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
+++ b/cdk/lib/__snapshots__/mobile-fastly-cache-purger.test.ts.snap
@@ -4,8 +4,6 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [
-      "GuDistributionBucketParameter",
-      "GuLambdaFunction",
       "GuLambdaDockerFunction",
     ],
     "gu:cdk:version": "TEST",
@@ -15,11 +13,6 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
       "Default": "dev",
       "Description": "Tag to be used for the image URL, e.g. riff raff build id",
       "Type": "String",
-    },
-    "DistributionBucketName": {
-      "Default": "/account/services/artifact.bucket",
-      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
-      "Type": "AWS::SSM::Parameter::Value<String>",
     },
   },
   "Resources": {
@@ -149,90 +142,6 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
       "Properties": {
         "PolicyDocument": {
           "Statement": [
-            {
-              "Action": [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                    ],
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                      "/mobile-fastly-cache-purger/TEST/mobile-fastly-cache-purger/mobile-fastly-cache-purger.jar",
-                    ],
-                  ],
-                },
-              ],
-            },
-            {
-              "Action": "ssm:GetParametersByPath",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/TEST/mobile-fastly-cache-purger/mobile-fastly-cache-purger",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "ssm:GetParameters",
-                "ssm:GetParameter",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/TEST/mobile-fastly-cache-purger/mobile-fastly-cache-purger/*",
-                  ],
-                ],
-              },
-            },
             {
               "Action": [
                 "sqs:ReceiveMessage",
@@ -394,64 +303,6 @@ exports[`The MobileFastlyCachePurger stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::SQS::QueuePolicy",
-    },
-    "mobilefastlycachepurgerFDB90D2A": {
-      "DependsOn": [
-        "ExecutionRoleDefaultPolicyA5B92313",
-        "ExecutionRole605A040B",
-      ],
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "DistributionBucketName",
-          },
-          "S3Key": "mobile-fastly-cache-purger/TEST/mobile-fastly-cache-purger/mobile-fastly-cache-purger.jar",
-        },
-        "Environment": {
-          "Variables": {
-            "APP": "mobile-fastly-cache-purger",
-            "App": "mobile-fastly-cache-purger",
-            "STACK": "mobile-fastly-cache-purger",
-            "STAGE": "TEST",
-            "Stack": "mobile-fastly-cache-purger",
-            "Stage": "TEST",
-          },
-        },
-        "FunctionName": "mobile-fastly-cache-purger-cdk-TEST",
-        "Handler": "PurgerLambda::handleRequest",
-        "MemorySize": 1024,
-        "Role": {
-          "Fn::GetAtt": [
-            "ExecutionRole605A040B",
-            "Arn",
-          ],
-        },
-        "Runtime": "java11",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "mobile-fastly-cache-purger",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/mobile-fastly-cache-purger",
-          },
-          {
-            "Key": "Stack",
-            "Value": "mobile-fastly-cache-purger",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "Timeout": 60,
-      },
-      "Type": "AWS::Lambda::Function",
     },
     "mobilefastlycachepurgerv23E8BE308": {
       "DependsOn": [

--- a/cdk/lib/environment-agnostic-resources.ts
+++ b/cdk/lib/environment-agnostic-resources.ts
@@ -6,6 +6,11 @@ import {Repository, TagMutability} from "aws-cdk-lib/aws-ecr";
 import { FederatedPrincipal, PolicyDocument, PolicyStatement, Role } from "aws-cdk-lib/aws-iam";
 import { CfnOutput } from 'aws-cdk-lib/core'
 
+
+/*
+* This is used to create the ecr repository to host the docker image
+* but does not need to be managed by riff raff deploys
+*  */
 export class EnvironmentAgnosticResources extends GuStack {
     constructor(scope: App, id: string, props: GuStackProps) {
         super(scope, id, props);

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -1,6 +1,5 @@
 import type {GuStackProps} from '@guardian/cdk/lib/constructs/core';
 import {GuStack} from '@guardian/cdk/lib/constructs/core';
-import {GuLambdaFunction} from '@guardian/cdk/lib/constructs/lambda';
 import {GuardianAwsAccounts} from '@guardian/private-infrastructure-config';
 import type {App} from 'aws-cdk-lib';
 import {CfnParameter, Duration, Fn} from 'aws-cdk-lib';

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -5,7 +5,6 @@ import type {App} from 'aws-cdk-lib';
 import {CfnParameter, Duration, Fn} from 'aws-cdk-lib';
 // eslint-disable-next-line import/no-namespace -- no default export
 import * as iam from 'aws-cdk-lib/aws-iam';
-import {Runtime} from 'aws-cdk-lib/aws-lambda';
 // eslint-disable-next-line import/no-namespace -- no default export
 import * as lambdaEventSources from 'aws-cdk-lib/aws-lambda-event-sources';
 import {Topic} from 'aws-cdk-lib/aws-sns';

--- a/cdk/lib/mobile-fastly-cache-purger.ts
+++ b/cdk/lib/mobile-fastly-cache-purger.ts
@@ -61,21 +61,6 @@ export class MobileFastlyCachePurger extends GuStack {
 			}
 		})
 
-		new GuLambdaFunction(this, 'mobile-fastly-cache-purger', {
-			handler: 'PurgerLambda::handleRequest',
-			functionName: `mobile-fastly-cache-purger-cdk-${this.stage}`,
-			timeout: Duration.seconds(60),
-			environment: {
-				App: 'mobile-fastly-cache-purger',
-				Stack: this.stack,
-				Stage: this.stage,
-			},
-			runtime: Runtime.JAVA_11,
-			app: 'mobile-fastly-cache-purger',
-			fileName: `mobile-fastly-cache-purger.jar`,
-			role: executionRole,
-		});
-
 		const imageRepositoryArn = Fn.importValue('mobile-fastly-cache-purger-repository-arn')
 		const imageRepositoryName = Fn.importValue('mobile-fastly-cache-purger-repository-name')
 		const handler = new GuLambdaDockerFunction(this, 'mobile-fastly-cache-purger-v2', {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This deletes the previous lambda from the cdk script, which has been superseded by a lambda function running on docker. 

This also takes the `EnvironmentAgnosticResources` script out of being managed by riff raff, as this script only needs to applied once

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
