### PR TITLE
Batch dependabot updates in /cdk

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,9 @@ updates:
       - dependency-name: 'aws-cdk'
       - dependency-name: 'aws-cdk-lib'
       - dependency-name: 'constructs'
-
+    groups:
+              all:
+                patterns: ["*"] # group all cdk dpendencies together
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
## What does this change?
At the moment dependabot is opening separate PRs for each npm package in the cdk folder.

Batch them together since they will be easier to review and test.